### PR TITLE
Skip non-RPC methods in RegisterService. Fixes #5

### DIFF
--- a/birpc.go
+++ b/birpc.go
@@ -51,11 +51,19 @@ func getRPCMethodsOfType(object interface{}) []*function {
 	for i := 0; i < type_.NumMethod(); i++ {
 		method := type_.Method(i)
 
-		if method.PkgPath != "" {
-			// skip unexported method
+		if method.PkgPath != "" ||
+			method.Type.NumIn() < 3 ||
+			method.Type.In(2).Kind() != reflect.Ptr ||
+			method.Type.NumOut() != 1 ||
+			method.Type.Out(0).Name() != "error" {
+			// skip if:
+			// - unexported method;
+			// - method has fewer than two arguments;
+			// - second argument is not a pointer;
+			// - zero or more than one return value; or
+			// - single non-error return value
 			continue
 		}
-		// TODO verify more
 
 		fn := &function{
 			receiver: reflect.ValueOf(object),


### PR DESCRIPTION
From [net/rpc](http://golang.org/pkg/net/rpc/#Register):

> Only methods that satisfy these criteria will be made available for remote access; other methods will be ignored:
> - the method is exported.
> - the method has two arguments, both exported (or builtin) types.
> - the method's second argument is a pointer.
> - the method has return type error.

All this PR does is add support for registering types that have exported methods not intended for RPC use, according to the above criteria.
